### PR TITLE
Update inferRelationships to recognize inferred ids

### DIFF
--- a/cmd/sponged/handlers/data.go
+++ b/cmd/sponged/handlers/data.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/ardanlabs/kit/db"
 	"github.com/ardanlabs/kit/web/app"
+	"github.com/cayleygraph/cayley"
 	"github.com/coralproject/shelf/internal/sponge/item"
+	"github.com/coralproject/shelf/internal/wire"
 )
 
 // dataHandle maintains the set of handlers for the data api, which is responsible
@@ -51,6 +53,18 @@ func (dataHandle) Upsert(c *app.Context) error {
 		return err
 	}
 
+	// Prepare the generic item data map.
+	itMap := map[string]interface{}{
+		"item_id": it.ID,
+		"type":    it.Type,
+		"version": it.Version,
+		"data":    it.Data,
+	}
+
+	// Infer relationships and add them to the graph.
+	if err := wire.AddToGraph(c.SessionID, c.Ctx["DB"].(*db.DB), c.Ctx["Graph"].(*cayley.Handle), itMap); err != nil {
+		return err
+	}
 	// Respond with no content success.
 	c.Respond(nil, http.StatusNoContent)
 	return nil

--- a/cmd/sponged/handlers/data.go
+++ b/cmd/sponged/handlers/data.go
@@ -65,6 +65,7 @@ func (dataHandle) Upsert(c *app.Context) error {
 	if err := wire.AddToGraph(c.SessionID, c.Ctx["DB"].(*db.DB), c.Ctx["Graph"].(*cayley.Handle), itMap); err != nil {
 		return err
 	}
+
 	// Respond with no content success.
 	c.Respond(nil, http.StatusNoContent)
 	return nil

--- a/cmd/sponged/tests/data_test.go
+++ b/cmd/sponged/tests/data_test.go
@@ -38,7 +38,7 @@ func TestUpsertData(t *testing.T) {
 		//----------------------------------------------------------------------
 		// Insert the Item.
 
-		typ := "test_type"
+		typ := "PTEST_comment"
 		url := "/1.0/data/" + typ
 		r := tests.NewRequest("POST", url, bytes.NewBuffer(itemStrData))
 		w := httptest.NewRecorder()

--- a/internal/wire/pattern/model.go
+++ b/internal/wire/pattern/model.go
@@ -17,7 +17,7 @@ func init() {
 // within an item.
 type Inference struct {
 	RelIDField string `bson:"related_ID_field" json:"related_ID_field" validate:"required,min=2"`
-	RelType    string `bson:"related_type" json:"related_type" validate:"min=2"`
+	RelType    string `bson:"related_type" json:"related_type"`
 	Predicate  string `bson:"predicate" json:"predicate" validate:"required,min=2"`
 	Direction  string `bson:"direction" json:"direction" validate:"required,min=2"`
 	Required   bool   `bson:"required" json:"required"`

--- a/internal/wire/pattern/model.go
+++ b/internal/wire/pattern/model.go
@@ -17,6 +17,7 @@ func init() {
 // within an item.
 type Inference struct {
 	RelIDField string `bson:"related_ID_field" json:"related_ID_field" validate:"required,min=2"`
+	RelType    string `bson:"related_type" json:"related_type" validate:"min=2"`
 	Predicate  string `bson:"predicate" json:"predicate" validate:"required,min=2"`
 	Direction  string `bson:"direction" json:"direction" validate:"required,min=2"`
 	Required   bool   `bson:"required" json:"required"`

--- a/internal/wire/pattern/patternfix/patterns_with_related_types.json
+++ b/internal/wire/pattern/patternfix/patterns_with_related_types.json
@@ -1,0 +1,50 @@
+[
+	{
+		"type": "PTEST_comment",
+		"inferences": [
+			{
+				"related_ID_field": "author",
+				"related_type": "PTEST_user",
+				"predicate": "authored",
+				"direction": "in",
+				"required": true
+			},
+			{
+				"related_ID_field": "parent",
+				"related_type": "PTEST_parent",
+				"predicate": "parented_by",
+				"direction": "out",
+				"required": false
+			},
+			{
+				"related_ID_field": "asset",
+				"related_type": "PTEST_asset",
+				"predicate": "on",
+				"direction": "out",
+				"required": true
+			}
+		]
+	},
+	{
+		"type": "PTEST_user",
+		"inferences": [
+			{
+				"related_ID_field": "role",
+				"predicate": "has_role",
+				"direction": "out",
+				"required": true
+			}
+		]
+	},
+	{
+		"type": "PTEST_asset",
+		"inferences": [
+			{
+				"related_ID_field": "section",
+				"predicate": "part_of",
+				"direction": "out",
+				"required": false
+			}
+		]
+	}
+]

--- a/internal/wire/relationships.go
+++ b/internal/wire/relationships.go
@@ -226,7 +226,7 @@ func itemParse(itemIn map[string]interface{}) (parsedItem, error) {
 	for k, v := range dataMap {
 
 		vString, ok := v.(string)
-		if !ok {
+		if !ok || vString == "" {
 			continue
 		}
 		itemData[k] = vString

--- a/internal/wire/relationships.go
+++ b/internal/wire/relationships.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ardanlabs/kit/db"
 	"github.com/ardanlabs/kit/log"
@@ -135,6 +136,16 @@ func inferRelationships(context interface{}, db *db.DB, itemIn map[string]interf
 
 		// Check for the relevant field in the item.
 		if relID, ok := item.itemData[inf.RelIDField]; ok {
+
+			// If the rel field is empty, do not create the quad.
+			if relID == "" {
+				continue
+			}
+
+			// If we are using source ids and rel types, compose the id.
+			if inf.RelType != "" {
+				relID = fmt.Sprintf("%s_%v", inf.RelType, relID)
+			}
 
 			// Add the relationship parameters.
 			switch inf.Direction {


### PR DESCRIPTION
This pr adds the ability for wire to understand inferred ids (type_source_id) and properly create cayley quads.