### PR TITLE
Follow up on centralizing item import

### DIFF
--- a/internal/sponge/item/item.go
+++ b/internal/sponge/item/item.go
@@ -49,6 +49,29 @@ func Upsert(context interface{}, db *db.DB, item *Item) error {
 	return nil
 }
 
+// GetByID retrieves a single item by ID from Mongo.
+func GetByID(context interface{}, db *db.DB, id string) (Item, error) {
+	log.Dev(context, "GetByID", "Started : ID[%s]", id)
+
+	// Get the items from Mongo.
+	var itm Item
+	f := func(c *mgo.Collection) error {
+		q := bson.M{"item_id": id}
+		log.Dev(context, "Find", "MGO : db.%s.find(%s)", c.Name, mongo.Query(q))
+		return c.Find(q).One(&itm)
+	}
+	if err := db.ExecuteMGO(context, Collection, f); err != nil {
+		if err == mgo.ErrNotFound {
+			err = ErrNotFound
+		}
+		log.Error(context, "GetByID", err, "Completed")
+		return itm, err
+	}
+
+	log.Dev(context, "GetByID", "Completed")
+	return itm, nil
+}
+
 // GetByIDs retrieves items by ID from Mongo.
 func GetByIDs(context interface{}, db *db.DB, ids []string) ([]Item, error) {
 	log.Dev(context, "GetByIDs", "Started : IDs%v", ids)

--- a/internal/sponge/item/item.go
+++ b/internal/sponge/item/item.go
@@ -57,7 +57,7 @@ func GetByID(context interface{}, db *db.DB, id string) (Item, error) {
 	var itm Item
 	f := func(c *mgo.Collection) error {
 		q := bson.M{"item_id": id}
-		log.Dev(context, "Find", "MGO : db.%s.find(%s)", c.Name, mongo.Query(q))
+		log.Dev(context, "GetByID", "MGO : db.%s.find(%s)", c.Name, mongo.Query(q))
 		return c.Find(q).One(&itm)
 	}
 	if err := db.ExecuteMGO(context, Collection, f); err != nil {

--- a/internal/sponge/item/item.go
+++ b/internal/sponge/item/item.go
@@ -16,7 +16,7 @@ import (
 const Collection = "items"
 
 // ErrNotFound is an error variable thrown when no results are returned from a Mongo query.
-var ErrNotFound = errors.New("Set Not found")
+var ErrNotFound = errors.New("Item(s) Not found")
 
 // Upsert upserts an item to the items collections.
 func Upsert(context interface{}, db *db.DB, item *Item) error {

--- a/internal/wire/pattern/model.go
+++ b/internal/wire/pattern/model.go
@@ -17,7 +17,7 @@ func init() {
 // within an item.
 type Inference struct {
 	RelIDField string `bson:"related_ID_field" json:"related_ID_field" validate:"required,min=2"`
-	RelType    string `bson:"related_type" json:"related_type"`
+	RelType    string `bson:"related_type,omitempty" json:"related_type,omitempty"`
 	Predicate  string `bson:"predicate" json:"predicate" validate:"required,min=2"`
 	Direction  string `bson:"direction" json:"direction" validate:"required,min=2"`
 	Required   bool   `bson:"required" json:"required"`

--- a/internal/wire/relationships.go
+++ b/internal/wire/relationships.go
@@ -214,11 +214,11 @@ func itemParse(itemIn map[string]interface{}) (parsedItem, error) {
 
 	itemID, ok := val.(string)
 	if !ok {
-		return parsedItem{}, ErrItemType
+		return parsedItem{}, ErrItemID
 	}
 
 	if itemID == "" {
-		return parsedItem{}, ErrItemType
+		return parsedItem{}, ErrItemID
 	}
 
 	// Validate and extract the item data.


### PR DESCRIPTION
# What this PR does:
- follow up on single item retrieval in the item API
- update the item import process to use the single item retrieval.

# How to test this PR:
- `go test ./...`