### PR TITLE
Proxy Xenia endpoints

### DIFF
--- a/cmd/corald/routes/routes.go
+++ b/cmd/corald/routes/routes.go
@@ -112,6 +112,12 @@ func routes(a *app.App) {
 				return "/v1/exec/" + c.Params["query_set"]
 			}))
 
+	// Execute xenia queries directly
+	a.Handle("GET", "/v1/exec/:query_set", handlers.Proxy(xeniadURL, nil))
+
+	// Post a new query to xenia
+	a.Handle("PUT", "/v1/query", handlers.Proxy(xeniadURL, nil))
+
 	a.Handle("PUT", "/v1/item",
 		handlers.Proxy(spongedURL,
 			func(c *app.Context) string {

--- a/cmd/corald/routes/routes.go
+++ b/cmd/corald/routes/routes.go
@@ -112,10 +112,10 @@ func routes(a *app.App) {
 				return "/v1/exec/" + c.Params["query_set"]
 			}))
 
-	// Execute xenia queries directly
+	// Execute xenia queries directly.
 	a.Handle("GET", "/v1/exec/:query_set", handlers.Proxy(xeniadURL, nil))
 
-	// Post a new query to xenia
+	// Send a new query to xenia.
 	a.Handle("PUT", "/v1/query", handlers.Proxy(xeniadURL, nil))
 
 	a.Handle("PUT", "/v1/item",

--- a/cmd/corald/routes/routes.go
+++ b/cmd/corald/routes/routes.go
@@ -113,10 +113,25 @@ func routes(a *app.App) {
 			}))
 
 	// Execute xenia queries directly.
-	a.Handle("GET", "/v1/exec/:query_set", handlers.Proxy(xeniadURL, nil))
+	a.Handle("GET", "/v1/exec/:query_set",
+		handlers.Proxy(xeniadURL,
+			func(c *app.Context) string {
+				return "/v1/exec/" + c.Params["query_set"]
+			}))
 
 	// Send a new query to xenia.
-	a.Handle("PUT", "/v1/query", handlers.Proxy(xeniadURL, nil))
+	a.Handle("PUT", "/v1/query",
+		handlers.Proxy(xeniadURL,
+			func(c *app.Context) string {
+				return "/v1/query"
+			}))
+
+	// Execute a custom xenia query.
+	a.Handle("POST", "/v1/exec",
+		handlers.Proxy(xeniadURL,
+			func(c *app.Context) string {
+				return "/v1/exec"
+			}))
 
 	a.Handle("PUT", "/v1/item",
 		handlers.Proxy(spongedURL,


### PR DESCRIPTION
There are times that FE does not need to query views but the Items collection. We should have a way to query it without creating views for it.

FE needs to get a list of untouched comments. We can just do an aggregation pipeline query instead of creating a view.

Related to: https://www.pivotaltracker.com/story/show/130312275