### PR TITLE
Added querystring option for auth midware

### DIFF
--- a/cmd/askd/routes/routes.go
+++ b/cmd/askd/routes/routes.go
@@ -102,12 +102,14 @@ func routes(a *app.App) {
 	if publicKey != "" {
 		log.Dev("startup", "Init", "Initializing Auth")
 
-		authm, err := auth.Midware(publicKey, auth.MidwareOpts{
-			// We are allowing the query string to act as the access token provider
-			// because this service has endpoints that are accessed directly currently
-			// and we need someway to authenticate to these endpoints.
+		// We are allowing the query string to act as the access token provider
+		// because this service has endpoints that are accessed directly currently
+		// and we need someway to authenticate to these endpoints.
+		authmOpts := auth.MidwareOpts{
 			AllowQueryString: true,
-		})
+		}
+
+		authm, err := auth.Midware(publicKey, authmOpts)
 		if err != nil {
 			log.Error("startup", "Init", err, "Initializing Auth")
 			os.Exit(1)

--- a/cmd/askd/routes/routes.go
+++ b/cmd/askd/routes/routes.go
@@ -102,7 +102,12 @@ func routes(a *app.App) {
 	if publicKey != "" {
 		log.Dev("startup", "Init", "Initializing Auth")
 
-		authm, err := auth.Midware(publicKey)
+		authm, err := auth.Midware(publicKey, auth.MidwareOpts{
+			// We are allowing the query string to act as the access token provider
+			// because this service has endpoints that are accessed directly currently
+			// and we need someway to authenticate to these endpoints.
+			AllowQueryString: true,
+		})
 		if err != nil {
 			log.Error("startup", "Init", err, "Initializing Auth")
 			os.Exit(1)

--- a/cmd/corald/routes/routes.go
+++ b/cmd/corald/routes/routes.go
@@ -50,7 +50,7 @@ func API(testing ...bool) http.Handler {
 	if publicKey != "" {
 		log.Dev("startup", "Init", "Initializing Auth")
 
-		authm, err := auth.Midware(publicKey)
+		authm, err := auth.Midware(publicKey, auth.MidwareOpts{})
 		if err != nil {
 			log.Error("startup", "Init", err, "Initializing Auth")
 			os.Exit(1)

--- a/cmd/sponged/routes/routes.go
+++ b/cmd/sponged/routes/routes.go
@@ -67,7 +67,7 @@ func API() http.Handler {
 	if publicKey != "" {
 		log.Dev("startup", "Init", "Initializing Auth")
 
-		authm, err := auth.Midware(publicKey)
+		authm, err := auth.Midware(publicKey, auth.MidwareOpts{})
 		if err != nil {
 			log.Error("startup", "Init", err, "Initializing Auth")
 			os.Exit(1)

--- a/cmd/xeniad/routes/routes.go
+++ b/cmd/xeniad/routes/routes.go
@@ -70,7 +70,7 @@ func API(testing ...bool) http.Handler {
 	if publicKey != "" {
 		log.Dev("startup", "Init", "Initializing Auth")
 
-		authm, err := auth.Midware(publicKey)
+		authm, err := auth.Midware(publicKey, auth.MidwareOpts{})
 		if err != nil {
 			log.Error("startup", "Init", err, "Initializing Auth")
 			os.Exit(1)

--- a/internal/platform/auth/midware.go
+++ b/internal/platform/auth/midware.go
@@ -40,11 +40,10 @@ func Midware(publicKeyBase64Str string, config MidwareOpts) (app.Middleware, err
 			// Extract the token from the Authorization header provided on the request.
 			tokenString := c.Request.Header.Get("Authorization")
 
+			// In the event that the request does not have a header key for the
+			// Authorization header, and we are allowed to check the query string, then
+			// we need to try and access it from the URL query parameters.
 			if tokenString == "" && config.AllowQueryString {
-
-				// In the event that the request does not have a header key for the
-				// Authorization header, then we need to try and access it from the URL
-				// query parameters if this was enabled from our config.
 				tokenString = c.Request.URL.Query().Get("access_token")
 			}
 

--- a/internal/platform/auth/midware.go
+++ b/internal/platform/auth/midware.go
@@ -14,6 +14,7 @@ var ErrInvalidToken = errors.New("invalid token")
 
 // MidwareOpts describes the options for configuring the Midware.
 type MidwareOpts struct {
+
 	// AllowQueryString is true when we want to allow accessing the tokenString
 	// from the query string as a fallback.
 	AllowQueryString bool


### PR DESCRIPTION
I've identified an endpoint that currently would/will have issues if deployed related to auth (on askd). This is the "download as csv" endpoint. As the web browser can not send a header along with an anchor link/file download, we needed a way to provide the access token in some other way to still validate the request.

This PR creates a new option for the midware which adds this as an option and selectively enables it for the askd service. This is a patch to the issue relating to "who should create a file" problem that we've tabled thus far.

Specifically, this allows a url param of `?access_token=...` on askd endpoints to provide the access token.