### PR TITLE
Ensured that only the host component of the bind is grabbed

### DIFF
--- a/cmd/askd/main.go
+++ b/cmd/askd/main.go
@@ -52,7 +52,7 @@ func main() {
 		writeTimeout = 30 * time.Second
 	)
 
-	host := cfg.MustString(cfgHost)
+	host := cfg.MustURL(cfgHost).Host
 
 	log.User("startup", "Init", "Binding web service to %s", host)
 

--- a/cmd/corald/main.go
+++ b/cmd/corald/main.go
@@ -52,7 +52,7 @@ func main() {
 		writeTimeout = 30 * time.Second
 	)
 
-	host := cfg.MustString(cfgHost)
+	host := cfg.MustURL(cfgHost).Host
 
 	log.User("startup", "Init", "Binding web service to %s", host)
 

--- a/cmd/sponged/main.go
+++ b/cmd/sponged/main.go
@@ -52,7 +52,7 @@ func main() {
 		writeTimeout = 30 * time.Second
 	)
 
-	host := cfg.MustString(cfgHost)
+	host := cfg.MustURL(cfgHost).Host
 
 	log.User("startup", "Init", "Binding web service to %s", host)
 

--- a/cmd/xeniad/main.go
+++ b/cmd/xeniad/main.go
@@ -52,7 +52,7 @@ func main() {
 		writeTimeout = 30 * time.Second
 	)
 
-	host := cfg.MustString(cfgHost)
+	host := cfg.MustURL(cfgHost).Host
 
 	log.User("startup", "Init", "Binding web service to %s", host)
 


### PR DESCRIPTION
This PR ensures that only the host component of the bind is ever used. This resolves some config issue that we have had deploying.