### PR TITLE
Removed `os.Getwd()` from path specs, ensured all cmd returns errors

### DIFF
--- a/cmd/sponge/cmditem/delete.go
+++ b/cmd/sponge/cmditem/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes an Item record by ID.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.ID, "ID", "i", "", "Item ID.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/item/" + delete.ID
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Item : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Item : Deleted")
+	return nil
 }

--- a/cmd/sponge/cmditem/get.go
+++ b/cmd/sponge/cmditem/get.go
@@ -1,6 +1,8 @@
 package cmditem
 
 import (
+	"fmt"
+
 	"github.com/coralproject/shelf/cmd/sponge/web"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +24,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves all item records matching the supplied IDs.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.IDs, "IDs", "i", "", "Item IDs.")
@@ -31,20 +33,20 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/item"
 
 	if get.IDs == "" {
-		cmd.Help()
-		return
+		return fmt.Errorf("at least one id required")
 	}
 
 	url += "/" + get.IDs
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Items : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/sponge/cmdpattern/delete.go
+++ b/cmd/sponge/cmdpattern/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a Pattern record by type.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.ptype, "type", "t", "", "Type of the Pattern.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/pattern/" + delete.ptype
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Pattern : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Pattern : Deleted")
+	return nil
 }

--- a/cmd/sponge/cmdpattern/get.go
+++ b/cmd/sponge/cmdpattern/get.go
@@ -9,7 +9,7 @@ var getLong = `Retrieves pattern records from the system with the optional suppl
 
 Example:
 	pattern get
-	
+
 	pattern get -t type
 `
 
@@ -24,7 +24,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves all pattern records, or those matching an optional type.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.ptype, "type", "t", "", "Pattern type.")
@@ -33,7 +33,7 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/pattern"
 
@@ -43,8 +43,9 @@ func runGet(cmd *cobra.Command, args []string) {
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Pattern : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/wire/cmdview/execute.go
+++ b/cmd/wire/cmdview/execute.go
@@ -2,6 +2,7 @@ package cmdview
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/coralproject/shelf/internal/wire"
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ func addExecute() {
 		Use:   "execute",
 		Short: "Execute executes a view based on input parameters.",
 		Long:  executeLong,
-		Run:   runExecute,
+		RunE:  runExecute,
 	}
 
 	cmd.Flags().StringVarP(&execute.viewName, "name", "n", "", "View name")
@@ -39,13 +40,12 @@ func addExecute() {
 }
 
 // runExecute is the code that implements the execute command.
-func runExecute(cmd *cobra.Command, args []string) {
+func runExecute(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Executing View : Name[%s]\n", execute.viewName)
 
 	// Validate the input parameters.
 	if execute.viewName == "" || execute.itemKey == "" {
-		cmd.Help()
-		return
+		return fmt.Errorf("view name and item key must be specified")
 	}
 
 	// Ready the view parameters.
@@ -59,17 +59,16 @@ func runExecute(cmd *cobra.Command, args []string) {
 	// Execute the view.
 	results, err := wire.Execute("", mgoDB, graphDB, &viewParams)
 	if err != nil {
-		cmd.Println("Executing View : ", err)
-		return
+		return err
 	}
 
 	// Prepare the results for printing.
 	data, err := json.MarshalIndent(results, "", "    ")
 	if err != nil {
-		cmd.Println("Executing View : ", err)
-		return
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", string(data))
 	cmd.Println("\n", "Executing View : Executed")
+	return nil
 }

--- a/cmd/xenia/cmddb/create.go
+++ b/cmd/xenia/cmddb/create.go
@@ -31,7 +31,7 @@ func addCreate() {
 		Use:   "create [-f file]",
 		Short: "Creates a new database from a script file",
 		Long:  createLong,
-		Run:   runCreate,
+		RunE:  runCreate,
 	}
 
 	cmd.Flags().StringVarP(&create.file, "file", "f", "", "file path of script json file")
@@ -73,20 +73,20 @@ type Field struct {
 }
 
 // runCreate is the code that implements the create command.
-func runCreate(cmd *cobra.Command, args []string) {
+func runCreate(cmd *cobra.Command, args []string) error {
 	dbMeta, err := retrieveDatabaseMetadata(create.file)
 	if err != nil {
-		dbCmd.Printf("Error reading collections : %s : ERROR : %v\n", create.file, err)
-		return
+		return err
 	}
 
 	for _, col := range dbMeta.Cols {
 		cmd.Println("Creating collection", col.Name)
 		if err := createCollection(conn, dbMeta, &col, true); err != nil && err != ErrCollectionExists {
-			cmd.Println("ERROR:", err)
-			return
+			return err
 		}
 	}
+
+	return nil
 }
 
 // retrieveDatabaseMetadata reads the specified file and returns the database

--- a/cmd/xenia/cmdmask/delete.go
+++ b/cmd/xenia/cmdmask/delete.go
@@ -23,7 +23,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a Mask record by collection/field.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&get.collection, "collection", "c", "", "Name of the Collection.")
@@ -33,13 +33,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/mask/" + delete.collection + "/" + delete.field
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Mask : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Mask : Deleted")
+	return nil
 }

--- a/cmd/xenia/cmdmask/get.go
+++ b/cmd/xenia/cmdmask/get.go
@@ -23,7 +23,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves a Mask record by collection/field.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.collection, "collection", "c", "", "Name of the Collection.")
@@ -33,7 +33,7 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/mask"
 
@@ -47,8 +47,9 @@ func runGet(cmd *cobra.Command, args []string) {
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Mask : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdquery/delete.go
+++ b/cmd/xenia/cmdquery/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a Set record by name.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.name, "name", "n", "", "Name of the Set record.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/query/" + delete.name
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Set : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Set : Deleted")
+	return nil
 }

--- a/cmd/xenia/cmdquery/execute.go
+++ b/cmd/xenia/cmdquery/execute.go
@@ -27,7 +27,7 @@ func addExec() {
 		Use:   "exec",
 		Short: "Executes a Set by name.",
 		Long:  execLong,
-		Run:   runExec,
+		RunE:  runExec,
 	}
 
 	cmd.Flags().StringVarP(&exe.name, "name", "n", "", "Name of Set.")
@@ -37,7 +37,7 @@ func addExec() {
 }
 
 // runExec is the code that implements the execute command.
-func runExec(cmd *cobra.Command, args []string) {
+func runExec(cmd *cobra.Command, args []string) error {
 	vars := make(map[string]string)
 	if exe.vars != "" {
 		vs := strings.Split(exe.vars, ",")
@@ -50,11 +50,11 @@ func runExec(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	runExecWeb(cmd, vars)
+	return runExecWeb(cmd, vars)
 }
 
 // runExecWeb issues the command talking to the web service.
-func runExecWeb(cmd *cobra.Command, vars map[string]string) {
+func runExecWeb(cmd *cobra.Command, vars map[string]string) error {
 	verb := "GET"
 	url := "/v1/exec/" + exe.name
 
@@ -74,8 +74,9 @@ func runExecWeb(cmd *cobra.Command, vars map[string]string) {
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Set List : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdquery/get.go
+++ b/cmd/xenia/cmdquery/get.go
@@ -22,7 +22,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves a Set record by name.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.name, "name", "n", "", "Name of the Set.")
@@ -31,14 +31,15 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/query/" + get.name
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Set : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdquery/index.go
+++ b/cmd/xenia/cmdquery/index.go
@@ -27,7 +27,7 @@ func addIndex() {
 		Use:   "index",
 		Short: "Index adds or updates a Set from a file or directory.",
 		Long:  indexLong,
-		Run:   runIndex,
+		RunE:  runIndex,
 	}
 
 	cmd.Flags().StringVarP(&index.name, "name", "n", "", "Name of the Set.")
@@ -36,13 +36,12 @@ func addIndex() {
 }
 
 // runIndex issues the command talking to the web service.
-func runIndex(cmd *cobra.Command, args []string) {
+func runIndex(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Ensure Indexes : Name[%s]\n", index.name)
 
 	set, err := runGetSet(cmd, index.name)
 	if err != nil {
-		cmd.Println("Ensure Indexes : ", err)
-		return
+		return err
 	}
 
 	verb := "PUT"
@@ -50,19 +49,17 @@ func runIndex(cmd *cobra.Command, args []string) {
 
 	data, err := json.Marshal(set)
 	if err != nil {
-		cmd.Println("Ensure Indexes : ", err)
-		return
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", string(data))
 
 	if _, err := web.Request(cmd, verb, url, bytes.NewBuffer(data)); err != nil {
-		cmd.Println("Ensure Indexes : ", err)
-		return
+		return err
 	}
 
 	cmd.Println("\n", "Ensure Indexes : Ensured")
-	return
+	return nil
 }
 
 // runGetSet get a query set by name.

--- a/cmd/xenia/cmdquery/lists.go
+++ b/cmd/xenia/cmdquery/lists.go
@@ -17,20 +17,21 @@ func addList() {
 		Use:   "list",
 		Short: "Retrieves a list of all available Set names.",
 		Long:  listLong,
-		Run:   runList,
+		RunE:  runList,
 	}
 	queryCmd.AddCommand(cmd)
 }
 
 // runList issues the command talking to the web service.
-func runList(cmd *cobra.Command, args []string) {
+func runList(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/query"
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Set List : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdregex/delete.go
+++ b/cmd/xenia/cmdregex/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a Regex record by name.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.name, "name", "n", "", "Name of the Regex record.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/regex/" + get.name
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Regex : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Regex : Deleted")
+	return nil
 }

--- a/cmd/xenia/cmdregex/get.go
+++ b/cmd/xenia/cmdregex/get.go
@@ -22,7 +22,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves a Regex record by name.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.name, "name", "n", "", "Name of the Regex.")
@@ -31,14 +31,15 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/regex/" + get.name
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Regex : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdregex/list.go
+++ b/cmd/xenia/cmdregex/list.go
@@ -17,20 +17,21 @@ func addList() {
 		Use:   "list",
 		Short: "Retrieves a list of all available Regex names.",
 		Long:  listLong,
-		Run:   runList,
+		RunE:  runList,
 	}
 	regexCmd.AddCommand(cmd)
 }
 
 // runList issues the command talking to the web service.
-func runList(cmd *cobra.Command, args []string) {
+func runList(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/regex"
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Regex List : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdregex/upsert.go
+++ b/cmd/xenia/cmdregex/upsert.go
@@ -3,8 +3,8 @@ package cmdregex
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/coralproject/shelf/cmd/xenia/disk"
 	"github.com/coralproject/shelf/cmd/xenia/web"
@@ -32,7 +32,7 @@ func addUpsert() {
 		Use:   "upsert",
 		Short: "Upsert adds or updates a Regex from a file or directory.",
 		Long:  upsertLong,
-		Run:   runUpsert,
+		RunE:  runUpsert,
 	}
 
 	cmd.Flags().StringVarP(&upsert.path, "path", "p", "", "Path of Regex file or directory.")
@@ -41,42 +41,32 @@ func addUpsert() {
 }
 
 // runUpsert is the code that implements the upsert command.
-func runUpsert(cmd *cobra.Command, args []string) {
+func runUpsert(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Upserting Regex : Path[%s]\n", upsert.path)
 
 	if upsert.path == "" {
-		cmd.Help()
-		return
+		return fmt.Errorf("path must be provided")
 	}
 
-	pwd, err := os.Getwd()
-	if err != nil {
-		cmd.Println("Upserting Regex : ", err)
-		return
-	}
-
-	file := filepath.Join(pwd, upsert.path)
+	file := upsert.path
 
 	stat, err := os.Stat(file)
 	if err != nil {
-		cmd.Println("Upserting Regex : ", err)
-		return
+		return err
 	}
 
 	if !stat.IsDir() {
 		rgx, err := disk.LoadRegex("", file)
 		if err != nil {
-			cmd.Println("Upserting Regex : ", err)
-			return
+			return err
 		}
 
 		if err := runUpsertWeb(cmd, rgx); err != nil {
-			cmd.Println("Upserting Regex : ", err)
-			return
+			return err
 		}
 
 		cmd.Println("\n", "Upserting Regex : Upserted")
-		return
+		return nil
 	}
 
 	f := func(path string) error {
@@ -89,11 +79,11 @@ func runUpsert(cmd *cobra.Command, args []string) {
 	}
 
 	if err := disk.LoadDir(file, f); err != nil {
-		cmd.Println("Upserting Regex : ", err)
-		return
+		return err
 	}
 
 	cmd.Println("\n", "Upserting Regex : Upserted")
+	return nil
 }
 
 // runUpsertWeb issues the command talking to the web service.

--- a/cmd/xenia/cmdrelationship/delete.go
+++ b/cmd/xenia/cmdrelationship/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a Relationship record by predicate.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.predicate, "predicate", "p", "", "Preciate of the Relationship.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/relationship/" + delete.predicate
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Relationship : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Relationship : Deleted")
+	return nil
 }

--- a/cmd/xenia/cmdrelationship/get.go
+++ b/cmd/xenia/cmdrelationship/get.go
@@ -9,7 +9,7 @@ var getLong = `Retrieves relationships record from the system with the optional 
 
 Example:
 	relationship get
-	
+
 	relationship get -p predicate
 `
 
@@ -24,7 +24,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves all relationship records, or those matching an optional predicate.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.predicate, "predicate", "p", "", "Relationship predicate.")
@@ -33,7 +33,7 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/relationship"
 
@@ -43,8 +43,9 @@ func runGet(cmd *cobra.Command, args []string) {
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Relationship : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdrelationship/upsert.go
+++ b/cmd/xenia/cmdrelationship/upsert.go
@@ -3,8 +3,8 @@ package cmdrelationship
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/coralproject/shelf/cmd/xenia/disk"
 	"github.com/coralproject/shelf/cmd/xenia/web"
@@ -31,7 +31,7 @@ func addUpsert() {
 		Use:   "upsert",
 		Short: "Upsert adds or updates a relationship from a file or directory.",
 		Long:  upsertLong,
-		Run:   runUpsert,
+		RunE:  runUpsert,
 	}
 
 	cmd.Flags().StringVarP(&upsert.path, "path", "p", "", "Path of relationship file or directory.")
@@ -40,42 +40,32 @@ func addUpsert() {
 }
 
 // runUpsert is the code that implements the upsert command.
-func runUpsert(cmd *cobra.Command, args []string) {
+func runUpsert(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Upserting Relationship : Path[%s]\n", upsert.path)
 
 	if upsert.path == "" {
-		cmd.Help()
-		return
+		return fmt.Errorf("path must be provided")
 	}
 
-	pwd, err := os.Getwd()
-	if err != nil {
-		cmd.Println("Upserting Relationship : ", err)
-		return
-	}
-
-	file := filepath.Join(pwd, upsert.path)
+	file := upsert.path
 
 	stat, err := os.Stat(file)
 	if err != nil {
-		cmd.Println("Upserting Relationship : ", err)
-		return
+		return err
 	}
 
 	if !stat.IsDir() {
 		rel, err := disk.LoadRelationship("", file)
 		if err != nil {
-			cmd.Println("Upserting Relationship : ", err)
-			return
+			return err
 		}
 
 		if err := runUpsertWeb(cmd, rel); err != nil {
-			cmd.Println("Upserting Relationship : ", err)
-			return
+			return err
 		}
 
 		cmd.Println("\n", "Upserting Relationship : Upserted")
-		return
+		return nil
 	}
 
 	f := func(path string) error {
@@ -88,11 +78,11 @@ func runUpsert(cmd *cobra.Command, args []string) {
 	}
 
 	if err := disk.LoadDir(file, f); err != nil {
-		cmd.Println("Upserting Relationship : ", err)
-		return
+		return err
 	}
 
 	cmd.Println("\n", "Upserting Relationship : Upserted")
+	return nil
 }
 
 // runUpsertWeb issues the command talking to the web service.

--- a/cmd/xenia/cmdscript/delete.go
+++ b/cmd/xenia/cmdscript/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a Script record by name.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.name, "name", "n", "", "Name of the Script record.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/script/" + get.name
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting Script : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting Script : Deleted")
+	return nil
 }

--- a/cmd/xenia/cmdscript/get.go
+++ b/cmd/xenia/cmdscript/get.go
@@ -22,7 +22,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves a Script record by name.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.name, "name", "n", "", "Name of the Script.")
@@ -31,14 +31,15 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/script/" + get.name
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Script : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdscript/lists.go
+++ b/cmd/xenia/cmdscript/lists.go
@@ -17,20 +17,21 @@ func addList() {
 		Use:   "list",
 		Short: "Retrieves a list of all available Script names.",
 		Long:  listLong,
-		Run:   runList,
+		RunE:  runList,
 	}
 	scriptCmd.AddCommand(cmd)
 }
 
 // runList issues the command talking to the web service.
-func runList(cmd *cobra.Command, args []string) {
+func runList(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/script"
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting Script List : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdscript/upsert.go
+++ b/cmd/xenia/cmdscript/upsert.go
@@ -3,8 +3,8 @@ package cmdscript
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/coralproject/shelf/cmd/xenia/disk"
 	"github.com/coralproject/shelf/cmd/xenia/web"
@@ -32,7 +32,7 @@ func addUpsert() {
 		Use:   "upsert",
 		Short: "Upsert adds or updates a script from a file or directory.",
 		Long:  upsertLong,
-		Run:   runUpsert,
+		RunE:  runUpsert,
 	}
 
 	cmd.Flags().StringVarP(&upsert.path, "path", "p", "", "Path of script file or directory.")
@@ -41,42 +41,32 @@ func addUpsert() {
 }
 
 // runUpsert is the code that implements the upsert command.
-func runUpsert(cmd *cobra.Command, args []string) {
+func runUpsert(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Upserting Script : Path[%s]\n", upsert.path)
 
 	if upsert.path == "" {
-		cmd.Help()
-		return
+		return fmt.Errorf("path must be provided")
 	}
 
-	pwd, err := os.Getwd()
-	if err != nil {
-		cmd.Println("Upserting Script : ", err)
-		return
-	}
-
-	file := filepath.Join(pwd, upsert.path)
+	file := upsert.path
 
 	stat, err := os.Stat(file)
 	if err != nil {
-		cmd.Println("Upserting Script : ", err)
-		return
+		return err
 	}
 
 	if !stat.IsDir() {
 		scr, err := disk.LoadScript("", file)
 		if err != nil {
-			cmd.Println("Upserting Script : ", err)
-			return
+			return err
 		}
 
 		if err := runUpsertWeb(cmd, scr); err != nil {
-			cmd.Println("Upserting Script : ", err)
-			return
+			return err
 		}
 
 		cmd.Println("\n", "Upserting Script : Upserted")
-		return
+		return nil
 	}
 
 	f := func(path string) error {
@@ -89,11 +79,11 @@ func runUpsert(cmd *cobra.Command, args []string) {
 	}
 
 	if err := disk.LoadDir(file, f); err != nil {
-		cmd.Println("Upserting Script : ", err)
-		return
+		return err
 	}
 
 	cmd.Println("\n", "Upserting Script : Upserted")
+	return nil
 }
 
 // runUpsertWeb issues the command talking to the web service.

--- a/cmd/xenia/cmdview/delete.go
+++ b/cmd/xenia/cmdview/delete.go
@@ -22,7 +22,7 @@ func addDel() {
 		Use:   "delete",
 		Short: "Removes a View record by name.",
 		Long:  deleteLong,
-		Run:   runDelete,
+		RunE:  runDelete,
 	}
 
 	cmd.Flags().StringVarP(&delete.name, "name", "n", "", "View name.")
@@ -31,13 +31,14 @@ func addDel() {
 }
 
 // runDelete issues the command talking to the web service.
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	verb := "DELETE"
 	url := "/v1/view/" + delete.name
 
 	if _, err := web.Request(cmd, verb, url, nil); err != nil {
-		cmd.Println("Deleting View : ", err)
+		return err
 	}
 
 	cmd.Println("Deleting View : Deleted")
+	return nil
 }

--- a/cmd/xenia/cmdview/get.go
+++ b/cmd/xenia/cmdview/get.go
@@ -24,7 +24,7 @@ func addGet() {
 		Use:   "get",
 		Short: "Retrieves all view records, or those matching an optional name.",
 		Long:  getLong,
-		Run:   runGet,
+		RunE:  runGet,
 	}
 
 	cmd.Flags().StringVarP(&get.name, "name", "n", "", "View name.")
@@ -33,7 +33,7 @@ func addGet() {
 }
 
 // runGet issues the command talking to the web service.
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	verb := "GET"
 	url := "/v1/view"
 
@@ -43,8 +43,9 @@ func runGet(cmd *cobra.Command, args []string) {
 
 	resp, err := web.Request(cmd, verb, url, nil)
 	if err != nil {
-		cmd.Println("Getting View : ", err)
+		return err
 	}
 
 	cmd.Printf("\n%s\n\n", resp)
+	return nil
 }

--- a/cmd/xenia/cmdview/upsert.go
+++ b/cmd/xenia/cmdview/upsert.go
@@ -3,8 +3,8 @@ package cmdview
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/coralproject/shelf/cmd/xenia/disk"
 	"github.com/coralproject/shelf/cmd/xenia/web"
@@ -31,7 +31,7 @@ func addUpsert() {
 		Use:   "upsert",
 		Short: "Upsert adds or updates a view from a file or directory.",
 		Long:  upsertLong,
-		Run:   runUpsert,
+		RunE:  runUpsert,
 	}
 
 	cmd.Flags().StringVarP(&upsert.path, "path", "p", "", "Path of view file or directory.")
@@ -40,42 +40,32 @@ func addUpsert() {
 }
 
 // runUpsert is the code that implements the upsert command.
-func runUpsert(cmd *cobra.Command, args []string) {
+func runUpsert(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Upserting View : Path[%s]\n", upsert.path)
 
 	if upsert.path == "" {
-		cmd.Help()
-		return
+		return fmt.Errorf("path must be provided")
 	}
 
-	pwd, err := os.Getwd()
-	if err != nil {
-		cmd.Println("Upserting View : ", err)
-		return
-	}
-
-	file := filepath.Join(pwd, upsert.path)
+	file := upsert.path
 
 	stat, err := os.Stat(file)
 	if err != nil {
-		cmd.Println("Upserting View : ", err)
-		return
+		return err
 	}
 
 	if !stat.IsDir() {
 		v, err := disk.LoadView("", file)
 		if err != nil {
-			cmd.Println("Upserting View : ", err)
-			return
+			return err
 		}
 
 		if err := runUpsertWeb(cmd, v); err != nil {
-			cmd.Println("Upserting View : ", err)
-			return
+			return err
 		}
 
 		cmd.Println("\n", "Upserting View : Upserted")
-		return
+		return nil
 	}
 
 	f := func(path string) error {
@@ -88,11 +78,11 @@ func runUpsert(cmd *cobra.Command, args []string) {
 	}
 
 	if err := disk.LoadDir(file, f); err != nil {
-		cmd.Println("Upserting View : ", err)
-		return
+		return err
 	}
 
 	cmd.Println("\n", "Upserting View : Upserted")
+	return nil
 }
 
 // runUpsertWeb issues the command talking to the web service.


### PR DESCRIPTION
This PR resolves errors with resolving paths and cmd tools not returning error codes when they fail.