### PR TITLE
Bocoup bugfix

### DIFF
--- a/cmd/askd/handlers/aggregations.go
+++ b/cmd/askd/handlers/aggregations.go
@@ -33,7 +33,13 @@ type AggregationKeys struct {
 func (aggregationHandle) Aggregate(c *web.Context) error {
 	id := c.Params["form_id"]
 
-	aggregations, err := form.AggregateFormSubmissions(c.SessionID, c.Ctx["DB"].(*db.DB), id)
+	// Aggregations can be based on Queries or Filters.
+	opts := submission.SearchOpts{
+		Query:    c.Request.URL.Query().Get("search"),
+		FilterBy: c.Request.URL.Query().Get("filterby"),
+	}
+
+	aggregations, err := form.AggregateFormSubmissions(c.SessionID, c.Ctx["DB"].(*db.DB), id, opts)
 	if err == mgo.ErrNotFound {
 		c.Respond(nil, http.StatusBadRequest)
 	}
@@ -55,7 +61,13 @@ func (aggregationHandle) Aggregate(c *web.Context) error {
 func (aggregationHandle) AggregateGroup(c *web.Context) error {
 	id := c.Params["form_id"]
 
-	aggregations, err := form.AggregateFormSubmissions(c.SessionID, c.Ctx["DB"].(*db.DB), id)
+	// Aggregations can be based on Queries or Filters.
+	opts := submission.SearchOpts{
+		Query:    c.Request.URL.Query().Get("search"),
+		FilterBy: c.Request.URL.Query().Get("filterby"),
+	}
+
+	aggregations, err := form.AggregateFormSubmissions(c.SessionID, c.Ctx["DB"].(*db.DB), id, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/ask/form/aggregation.go
+++ b/internal/ask/form/aggregation.go
@@ -334,6 +334,11 @@ func TextAggregate(context interface{}, db *db.DB, formID string, subs []submiss
 					continue
 				}
 
+				// Skip submissions with no choices for this quesiton.
+				if len(opts) == 0 {
+					continue
+				}
+
 				// Unpack the option.
 				op, ok := opts[0].(bson.M)
 				if !ok {

--- a/internal/ask/form/aggregation.go
+++ b/internal/ask/form/aggregation.go
@@ -49,12 +49,7 @@ type Group struct {
 
 // AggregateFormSubmissions retrieves the submissions for a form, groups them then
 // runs aggregations and counts for each one.
-func AggregateFormSubmissions(context interface{}, db *db.DB, id string) (map[string]Aggregation, error) {
-
-	// Aggregations are hardcoded to only work with bookmarked submissions.
-	opts := submission.SearchOpts{
-		FilterBy: "bookmarked",
-	}
+func AggregateFormSubmissions(context interface{}, db *db.DB, id string, opts submission.SearchOpts) (map[string]Aggregation, error) {
 
 	// Group the submissions.
 	groupedSubmissions, err := GroupSubmissions(context, db, id, 0, 0, opts)

--- a/internal/ask/form/aggregation.go
+++ b/internal/ask/form/aggregation.go
@@ -51,8 +51,13 @@ type Group struct {
 // runs aggregations and counts for each one.
 func AggregateFormSubmissions(context interface{}, db *db.DB, id string) (map[string]Aggregation, error) {
 
+	// Aggregations are hardcoded to only work with bookmarked submissions.
+	opts := submission.SearchOpts{
+		FilterBy: "bookmarked",
+	}
+
 	// Group the submissions.
-	groupedSubmissions, err := GroupSubmissions(context, db, id, 0, 0, submission.SearchOpts{})
+	groupedSubmissions, err := GroupSubmissions(context, db, id, 0, 0, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
All aggregation counts are now based on bookmarked submissions only.

Multiple choices without any selections now accounted for, preventing potential panics.